### PR TITLE
2024 video update move video styles

### DIFF
--- a/_assets/scss/modules/_projects.scss
+++ b/_assets/scss/modules/_projects.scss
@@ -21,37 +21,6 @@
 
 // project detail
 
-.project-detail .video {
-  width: 100%;
-  padding: 40px 0;
-  @include breakpoint($med) {
-    padding: 80px 0;
-  }
-  @include breakpoint($med) {
-    padding: 8vw 0;
-  }
-}
-
-.project-detail .video .video-responsive-container {
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 95vw;
-  overflow: hidden;
-  aspect-ratio: 16 / 9; /* Set aspect ratio here */
-
-  iframe {
-    width: 100% !important;
-    height: 100% !important;
-  }
-
-  @include breakpoint($small) {
-    max-width: 650px;
-  }
-  @include breakpoint($med) {
-    max-width: 750px;
-  }
-}
-
 .project-detail .content {
   @include breakpoint($med) {
     @include col-two-thirds(false);

--- a/_includes/video.html
+++ b/_includes/video.html
@@ -6,3 +6,43 @@
       </div>
     {% endif %}
 </div>
+
+<!-- SCSS not compiling. Likely missing build step on Siteleaf publish. Placing local styles in _includes template file for now.  -->
+<style>
+  .project-detail .video {
+    width: 100%;
+    padding: 40px 0;
+  }
+
+  @media (min-width: 948px) { /* $med breakpoint */
+    .project-detail .video {
+      padding: 8vw 0;
+    }
+  }
+
+  .project-detail .video .video-responsive-container {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 95vw;
+    overflow: hidden;
+    aspect-ratio: 16 / 9;
+  }
+
+  .project-detail .video .video-responsive-container iframe {
+    width: 100% !important;
+    height: 100% !important;
+  }
+
+  @media (min-width: 560px) { /* $small breakpoint */
+    .project-detail .video .video-responsive-container {
+      max-width: 650px;
+    }
+  }
+
+  @media (min-width: 948px) { /* $med breakpoint */
+    .project-detail .video .video-responsive-container {
+      max-width: 750px;
+    }
+  }
+
+</style>


### PR DESCRIPTION
Missing a build step somewhere and SCSS is not compiling. Circumventing this temporarily by moving SCSS to vanilla CSS in the _includes file. Temporary workaround until major critical CMS updates are requested.